### PR TITLE
README alternatives to arrows for shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,18 +34,13 @@ are rated with a [sharpness](#tuning-of-regular-pythagorean-accidentals) of up t
 
 - Set up keyboard shortcuts for the plugins:
   - For Tuning, we recommend using Alt+R (for "Retune")
-  - For Pitch up/down, consider using up/down arrow keys
-    - That will replace the function of up/down arrow key shortcuts in MuseScore (including
-      repositioning other elements)
-    - Before assigning the transposing plugins the up/down arrow keys shortcut, you will have to clear the following
-      shortcuts in the Shortcuts preferences menu with the 'Clear' button. (Edit -> Preferences -> Shortcuts)
-      - _Pitch up or move text or articulation up_
-      - _Pitch down or move text or articulation down_
-      - _Select string above (TAB only)_
-      - _Select string below (TAB only)_
-  - To keep the normal up/down arrow key functions, you could assign something else to the plugins, such as Alt+PgUp and Alt+PgDown
-  - You can search the shortcut preferences to explore what shortcuts are available without conflict\
-    or which need to be changed if you want to switch them to these plugins.
+  - For Pitch up/down, we recommend up/down arrow keys
+    - This will replace the function of up/down arrow key shortcuts in MuseScore (including repositioning other elements)
+    - So, before assigning the transposing plugins the up/down arrow keys shortcut, you will have to clear or change the following shortcuts in the Shortcuts preferences menu (Edit -> Preferences -> Shortcuts)
+      - _Pitch up or move text or articulation up_ (consider replacing with Alt+PgUp)
+      - _Pitch down or move text or articulation down_ (consider replacing with Alt+PgDn)
+      - _Select string above (TAB only)_ (suggest replacing with Alt+Up, which matches moving to next note above in staff)
+      - _Select string below (TAB only)_ (suggest replacing with Alt+Down, which matches moving to next note below in staff)
   - Ensure only one variant of each plugin has the keyboard shortcut assigned at a time.\
     If 'pitch up.qml' is assigned to the up arrow, then 'pitch up no dt.qml' cannot be assigned to the up arrow.\
     Both plugins may be enabled simultaneously, but they must have different keyboard shortcuts.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ are rated with a [sharpness](#tuning-of-regular-pythagorean-accidentals) of up t
   - Same as above, but prioritizes up/down arrows over semi/sesqui sharp/flat symbols wherever possible.
 
 - Set up keyboard shortcuts for the plugins:
-  - For Tuning, we recommend using alt+R (for "Retune")
+  - For Tuning, we recommend using Alt+R (for "Retune")
   - For Pitch up/down, consider using up/down arrow keys
     - That will replace the function of up/down arrow key shortcuts in MuseScore (including
       repositioning other elements)
@@ -43,7 +43,9 @@ are rated with a [sharpness](#tuning-of-regular-pythagorean-accidentals) of up t
       - _Pitch down or move text or articulation down_
       - _Select string above (TAB only)_
       - _Select string below (TAB only)_
-  - To keep the normal up/down arrow key functions, you could assign something else to the plugins, such as Alt+PgUp and Alt+PgDown; if you serch in the shortcut preferences, you can explore what shortcuts are available without conflict or which need to be changed if you want to switch them to these plugins
+  - To keep the normal up/down arrow key functions, you could assign something else to the plugins, such as Alt+PgUp and Alt+PgDown
+  - You can search the shortcut preferences to explore what shortcuts are available without conflict\
+    or which need to be changed if you want to switch them to these plugins.\
   - Ensure only one variant of each plugin has the keyboard shortcut assigned at a time.\
     If 'pitch up.qml' is assigned to the up arrow, then 'pitch up no dt.qml' cannot be assigned to the up arrow.\
     Both plugins may be enabled simultaneously, but they must have different keyboard shortcuts.

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ are rated with a [sharpness](#tuning-of-regular-pythagorean-accidentals) of up t
 - `pitch up no dt.qml`/`pitch down no dt.qml`:
   - Same as above, but prioritizes up/down arrows over semi/sesqui sharp/flat symbols wherever possible.
 
-To make plugin usage more ergonomic, it is recommended to assign the following keyboard shortcuts to the plugins:
-  - Tuning: alt + R
-  - Pitch up/down: up/down arrow keys
-    - The plugin is intended to replace the function of up/down arrow key shortcuts in MuseScore (including
+- Set up keyboard shortcuts for the plugins:
+  - For Tuning, we recommend using alt+R (for "Retune")
+  - For Pitch up/down, consider using up/down arrow keys
+    - That will replace the function of up/down arrow key shortcuts in MuseScore (including
       repositioning other elements)
     - Before assigning the transposing plugins the up/down arrow keys shortcut, you will have to clear the following
       shortcuts in the Shortcuts preferences menu with the 'Clear' button. (Edit -> Preferences -> Shortcuts)
@@ -43,9 +43,10 @@ To make plugin usage more ergonomic, it is recommended to assign the following k
       - _Pitch down or move text or articulation down_
       - _Select string above (TAB only)_
       - _Select string below (TAB only)_
-    - Ensure only one variant of each plugin has the keyboard shortcut assigned at a time.\
-      If 'pitch up.qml' is assigned to the up arrow, then 'pitch up no dt.qml' cannot be assigned to the up arrow.\
-      Although, both plugins may be enabled simultaneously and have different keyboard shortcuts assigned to each variant.
+  - To keep the normal up/down arrow key functions, you could assign something else to the plugins, such as Alt+PgUp and Alt+PgDown; if you serch in the shortcut preferences, you can explore what shortcuts are available without conflict or which need to be changed if you want to switch them to these plugins
+  - Ensure only one variant of each plugin has the keyboard shortcut assigned at a time.\
+    If 'pitch up.qml' is assigned to the up arrow, then 'pitch up no dt.qml' cannot be assigned to the up arrow.\
+    Both plugins may be enabled simultaneously, but they must have different keyboard shortcuts.
 
 ### Selecting the tuning system
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ are rated with a [sharpness](#tuning-of-regular-pythagorean-accidentals) of up t
       - _Select string below (TAB only)_
   - To keep the normal up/down arrow key functions, you could assign something else to the plugins, such as Alt+PgUp and Alt+PgDown
   - You can search the shortcut preferences to explore what shortcuts are available without conflict\
-    or which need to be changed if you want to switch them to these plugins.\
+    or which need to be changed if you want to switch them to these plugins.
   - Ensure only one variant of each plugin has the keyboard shortcut assigned at a time.\
     If 'pitch up.qml' is assigned to the up arrow, then 'pitch up no dt.qml' cannot be assigned to the up arrow.\
     Both plugins may be enabled simultaneously, but they must have different keyboard shortcuts.


### PR DESCRIPTION
Keeping the suggestion but adding notes about other options

Some people may want to keep arrow keys, especially for positioning of elements. Thus, it makes sense to offer a suggestion of alternative shortcuts.

I could have opened an issue, but it seemed easier to submit a PR to discuss directly.