### PR TITLE
Update to Musescore 4

### DIFF
--- a/pitch down no dt.qml
+++ b/pitch down no dt.qml
@@ -11,14 +11,17 @@ MuseScore {
         title: 'n-TET tuning plugin error:'
         text: 'Tuning system not supported, it requires an accidental that cannot be represented.\nOnly EDOs ranked up to sharp-8 are supported. See the README for more info.'
         onAccepted: {
-          Qt.quit();
+          quit();
         }
       }
 
-      version: "2.3.3"
+      version: "2.4.0"
       description: "Lowers selection (Shift-click) or individually selected notes (Ctrl-click) by 1 step of n EDO. " +
                    "This version prioritises up/down arrows over semisharp/flat accidentals whenever possible."
       menuPath: "Plugins.n-EDO.Lower Pitch By 1 Step (Arrows)"
+      title: "Lower Pitch By 1 Step (Arrows)"
+      categoryCode: "playback"
+      // thumbnailName: "something.png"
 
       // WARNING! This doesn't validate the accidental code!
       property variant customKeySigRegex: /\.(.*)\.(.*)\.(.*)\.(.*)\.(.*)\.(.*)\.(.*)/g
@@ -1106,6 +1109,7 @@ MuseScore {
         // sadly, there seems to be no way for the plugin to tell if the cursor
         // is in element-array selection mode which would have been helpful for
         // transposing individual note elements selected by alt+click.
+        curScore.startCmd();
         var cursor = curScore.newCursor();
         cursor.rewind(1);
         var startStaff;
@@ -1146,7 +1150,7 @@ MuseScore {
 
           if (curScore.selection.elements.length == 0) {
             clog('no individual selection. quitting.');
-            Qt.quit();
+            quit();
           } else {
             var selectedNotes = [];
             for (var i = 0; i < curScore.selection.elements.length; i++) {
@@ -1164,7 +1168,7 @@ MuseScore {
               clog('no selected note elements, defaulting to pitch-up/pitch-down shortcuts');
               // <UP DOWN VARIANT CHECKPOINT>
               cmd('pitch-down');
-              Qt.quit();
+              quit();
             }
 
             // These selected notes may be in any random order and may come from any staff
@@ -1660,7 +1664,7 @@ MuseScore {
                 }
 
                 if (cursor.element) {
-                  if (cursor.element.type == Ms.CHORD) {
+                  if (cursor.element.type == Element.CHORD) {
                     var graceChords = cursor.element.graceNotes;
                     for (var i = 0; i < graceChords.length; i++) {
                       // iterate through all grace chords
@@ -1742,6 +1746,7 @@ MuseScore {
             }
           }
         }
+        curScore.endCmd();
       }
 
       // Set a cursor to a specific position.
@@ -1827,7 +1832,7 @@ MuseScore {
           var firstAccidentalPropertyUndefinedNaturalTPC = undefined;
 
           while (tickOfThisBar !== -1 && cursor.segment && cursor.tick >= tickOfThisBar) {
-            if (cursor.element && cursor.element.type == Ms.CHORD) {
+            if (cursor.element && cursor.element.type == Element.CHORD) {
               // because this is backwards-traversing, it should look at the main chord first before grace chords.
               var notes = cursor.element.notes;
               var nNotesInSameLine = 0;
@@ -3024,7 +3029,7 @@ MuseScore {
           while (cursor.tick < tickOfThisBar && cursor.nextMeasure());
 
           while (cursor.segment && (tickOfNextBar === -1 || cursor.tick < tickOfNextBar)) {
-            if (cursor.element && cursor.element.type == Ms.CHORD) {
+            if (cursor.element && cursor.element.type == Element.CHORD) {
               var graceChords = cursor.element.graceNotes;
               for (var i = 0; i < graceChords.length; i++) {
                 // iterate through all grace chords
@@ -3590,7 +3595,7 @@ MuseScore {
         clog("hello n-edo");
 
         if (typeof curScore === 'undefined')
-              Qt.quit();
+              quit();
 
         var parms = {};
 
@@ -3620,6 +3625,6 @@ MuseScore {
         parms.currKeySig = parms.naturalKeySig
 
         applyToNotesInSelection(tuneNote, parms);
-        Qt.quit();
+        quit();
       }
 }

--- a/pitch down.qml
+++ b/pitch down.qml
@@ -11,13 +11,16 @@ MuseScore {
         title: 'n-TET tuning plugin error:'
         text: 'Tuning system not supported, it requires an accidental that cannot be represented.\nOnly EDOs ranked up to sharp-8 are supported. See the README for more info.'
         onAccepted: {
-          Qt.quit();
+          quit();
         }
       }
 
-      version: "2.3.3"
+      version: "2.4.0"
       description: "Lowers selection (Shift-click) or individually selected notes (Ctrl-click) by 1 step of n EDO."
       menuPath: "Plugins.n-EDO.Lower Pitch By 1 Step"
+      title: "Lower Pitch By 1 Step"
+      categoryCode: "playback"
+      // thumbnailName: "something.png"
 
       // WARNING! This doesn't validate the accidental code!
       property variant customKeySigRegex: /\.(.*)\.(.*)\.(.*)\.(.*)\.(.*)\.(.*)\.(.*)/g
@@ -1103,6 +1106,7 @@ MuseScore {
         // sadly, there seems to be no way for the plugin to tell if the cursor
         // is in element-array selection mode which would have been helpful for
         // transposing individual note elements selected by alt+click.
+        curScore.startCmd();
         var cursor = curScore.newCursor();
         cursor.rewind(1);
         var startStaff;
@@ -1143,7 +1147,7 @@ MuseScore {
 
           if (curScore.selection.elements.length == 0) {
             clog('no individual selection. quitting.');
-            Qt.quit();
+            quit();
           } else {
             var selectedNotes = [];
             for (var i = 0; i < curScore.selection.elements.length; i++) {
@@ -1161,7 +1165,7 @@ MuseScore {
               clog('no selected note elements, defaulting to pitch-up/pitch-down shortcuts');
               // <UP DOWN VARIANT CHECKPOINT>
               cmd('pitch-down');
-              Qt.quit();
+              quit();
             }
 
             // These selected notes may be in any random order and may come from any staff
@@ -1439,7 +1443,6 @@ MuseScore {
               // NOTE: note.parent.parent is equivalent to the Segment the current selected note belongs to.
               func(note, segment, parms, cursor);
             }
-
           }
         } else {
           // Standard implementation for phrase selection.
@@ -1657,7 +1660,7 @@ MuseScore {
                 }
 
                 if (cursor.element) {
-                  if (cursor.element.type == Ms.CHORD) {
+                  if (cursor.element.type == Element.CHORD) {
                     var graceChords = cursor.element.graceNotes;
                     for (var i = 0; i < graceChords.length; i++) {
                       // iterate through all grace chords
@@ -1739,6 +1742,7 @@ MuseScore {
             }
           }
         }
+        curScore.endCmd();
       }
 
       // Set a cursor to a specific position.
@@ -1824,7 +1828,7 @@ MuseScore {
           var firstAccidentalPropertyUndefinedNaturalTPC = undefined;
 
           while (tickOfThisBar !== -1 && cursor.segment && cursor.tick >= tickOfThisBar) {
-            if (cursor.element && cursor.element.type == Ms.CHORD) {
+            if (cursor.element && cursor.element.type == Element.CHORD) {
               // because this is backwards-traversing, it should look at the main chord first before grace chords.
               var notes = cursor.element.notes;
               var nNotesInSameLine = 0;
@@ -3022,7 +3026,7 @@ MuseScore {
           while (cursor.tick < tickOfThisBar && cursor.nextMeasure());
 
           while (cursor.segment && (tickOfNextBar === -1 || cursor.tick < tickOfNextBar)) {
-            if (cursor.element && cursor.element.type == Ms.CHORD) {
+            if (cursor.element && cursor.element.type == Element.CHORD) {
               var graceChords = cursor.element.graceNotes;
               for (var i = 0; i < graceChords.length; i++) {
                 // iterate through all grace chords
@@ -3588,7 +3592,7 @@ MuseScore {
         clog("hello n-edo");
 
         if (typeof curScore === 'undefined')
-              Qt.quit();
+              quit();
 
         var parms = {};
 
@@ -3618,6 +3622,6 @@ MuseScore {
         parms.currKeySig = parms.naturalKeySig
 
         applyToNotesInSelection(tuneNote, parms);
-        Qt.quit();
+        quit();
       }
 }

--- a/pitch up no dt.qml
+++ b/pitch up no dt.qml
@@ -11,14 +11,17 @@ MuseScore {
         title: 'n-TET tuning plugin error:'
         text: 'Tuning system not supported, it requires an accidental that cannot be represented.\nOnly EDOs ranked up to sharp-8 are supported. See the README for more info.'
         onAccepted: {
-          Qt.quit();
+          quit();
         }
       }
 
-      version: "2.3.3"
+      version: "2.4.0"
       description: "Raises selection (Shift-click) or individually selected notes (Ctrl-click) by 1 step of n EDO. " +
                    "This version prioritises up/down arrows over semisharp/flat accidentals whenever possible."
       menuPath: "Plugins.n-EDO.Raise Pitch By 1 Step (Arrows)"
+      title: "Raise Pitch By 1 Step (Arrows)"
+      categoryCode: "playback"
+      // thumbnailName: "something.png"
 
       // WARNING! This doesn't validate the accidental code!
       property variant customKeySigRegex: /\.(.*)\.(.*)\.(.*)\.(.*)\.(.*)\.(.*)\.(.*)/g
@@ -1106,6 +1109,7 @@ MuseScore {
         // sadly, there seems to be no way for the plugin to tell if the cursor
         // is in element-array selection mode which would have been helpful for
         // transposing individual note elements selected by alt+click.
+        curScore.startCmd();
         var cursor = curScore.newCursor();
         cursor.rewind(1);
         var startStaff;
@@ -1146,7 +1150,7 @@ MuseScore {
 
           if (curScore.selection.elements.length == 0) {
             clog('no individual selection. quitting.');
-            Qt.quit();
+            quit();
           } else {
             var selectedNotes = [];
             for (var i = 0; i < curScore.selection.elements.length; i++) {
@@ -1164,7 +1168,7 @@ MuseScore {
               clog('no selected note elements, defaulting to pitch-up/pitch-down shortcuts');
               // <UP DOWN VARIANT CHECKPOINT>
               cmd('pitch-up');
-              Qt.quit();
+              quit();
             }
 
             // These selected notes may be in any random order and may come from any staff
@@ -1660,7 +1664,7 @@ MuseScore {
                 }
 
                 if (cursor.element) {
-                  if (cursor.element.type == Ms.CHORD) {
+                  if (cursor.element.type == Element.CHORD) {
                     var graceChords = cursor.element.graceNotes;
                     for (var i = 0; i < graceChords.length; i++) {
                       // iterate through all grace chords
@@ -1742,6 +1746,7 @@ MuseScore {
             }
           }
         }
+        curScore.endCmd();
       }
 
       // Set a cursor to a specific position.
@@ -1827,7 +1832,7 @@ MuseScore {
           var firstAccidentalPropertyUndefinedNaturalTPC = undefined;
 
           while (tickOfThisBar !== -1 && cursor.segment && cursor.tick >= tickOfThisBar) {
-            if (cursor.element && cursor.element.type == Ms.CHORD) {
+            if (cursor.element && cursor.element.type == Element.CHORD) {
               // because this is backwards-traversing, it should look at the main chord first before grace chords.
               var notes = cursor.element.notes;
               var nNotesInSameLine = 0;
@@ -3024,7 +3029,7 @@ MuseScore {
           while (cursor.tick < tickOfThisBar && cursor.nextMeasure());
 
           while (cursor.segment && (tickOfNextBar === -1 || cursor.tick < tickOfNextBar)) {
-            if (cursor.element && cursor.element.type == Ms.CHORD) {
+            if (cursor.element && cursor.element.type == Element.CHORD) {
               var graceChords = cursor.element.graceNotes;
               for (var i = 0; i < graceChords.length; i++) {
                 // iterate through all grace chords
@@ -3590,7 +3595,7 @@ MuseScore {
         clog("hello n-edo");
 
         if (typeof curScore === 'undefined')
-              Qt.quit();
+              quit();
 
         var parms = {};
 
@@ -3620,6 +3625,6 @@ MuseScore {
         parms.currKeySig = parms.naturalKeySig
 
         applyToNotesInSelection(tuneNote, parms);
-        Qt.quit();
+        quit();
       }
 }

--- a/pitch up.qml
+++ b/pitch up.qml
@@ -11,13 +11,16 @@ MuseScore {
         title: 'n-TET tuning plugin error:'
         text: 'Tuning system not supported, it requires an accidental that cannot be represented.\nOnly EDOs ranked up to sharp-8 are supported. See the README for more info.'
         onAccepted: {
-          Qt.quit();
+          quit();
         }
       }
 
-      version: "2.3.3"
+      version: "2.4.0"
       description: "Raises selection (Shift-click) or individually selected notes (Ctrl-click) by 1 step of n EDO."
       menuPath: "Plugins.n-EDO.Raise Pitch By 1 Step"
+      title: "Raise Pitch By 1 Step"
+      categoryCode: "playback"
+      // thumbnailName: "something.png"
 
       // WARNING! This doesn't validate the accidental code!
       property variant customKeySigRegex: /\.(.*)\.(.*)\.(.*)\.(.*)\.(.*)\.(.*)\.(.*)/g
@@ -1105,6 +1108,7 @@ MuseScore {
         // sadly, there seems to be no way for the plugin to tell if the cursor
         // is in element-array selection mode which would have been helpful for
         // transposing individual note elements selected by alt+click.
+        curScore.startCmd();
         var cursor = curScore.newCursor();
         cursor.rewind(1);
         var startStaff;
@@ -1145,7 +1149,7 @@ MuseScore {
 
           if (curScore.selection.elements.length == 0) {
             clog('no individual selection. quitting.');
-            Qt.quit();
+            quit();
           } else {
             var selectedNotes = [];
             for (var i = 0; i < curScore.selection.elements.length; i++) {
@@ -1163,7 +1167,7 @@ MuseScore {
               clog('no selected note elements, defaulting to pitch-up/pitch-down shortcuts');
               // <UP DOWN VARIANT CHECKPOINT>
               cmd('pitch-up');
-              Qt.quit();
+              quit();
             }
 
             // These selected notes may be in any random order and may come from any staff
@@ -1659,7 +1663,7 @@ MuseScore {
                 }
 
                 if (cursor.element) {
-                  if (cursor.element.type == Ms.CHORD) {
+                  if (cursor.element.type == Element.CHORD) {
                     var graceChords = cursor.element.graceNotes;
                     for (var i = 0; i < graceChords.length; i++) {
                       // iterate through all grace chords
@@ -1741,6 +1745,7 @@ MuseScore {
             }
           }
         }
+        curScore.endCmd();
       }
 
       // Set a cursor to a specific position.
@@ -1826,7 +1831,7 @@ MuseScore {
           var firstAccidentalPropertyUndefinedNaturalTPC = undefined;
 
           while (tickOfThisBar !== -1 && cursor.segment && cursor.tick >= tickOfThisBar) {
-            if (cursor.element && cursor.element.type == Ms.CHORD) {
+            if (cursor.element && cursor.element.type == Element.CHORD) {
               // because this is backwards-traversing, it should look at the main chord first before grace chords.
               var notes = cursor.element.notes;
               var nNotesInSameLine = 0;
@@ -3023,7 +3028,7 @@ MuseScore {
           while (cursor.tick < tickOfThisBar && cursor.nextMeasure());
 
           while (cursor.segment && (tickOfNextBar === -1 || cursor.tick < tickOfNextBar)) {
-            if (cursor.element && cursor.element.type == Ms.CHORD) {
+            if (cursor.element && cursor.element.type == Element.CHORD) {
               var graceChords = cursor.element.graceNotes;
               for (var i = 0; i < graceChords.length; i++) {
                 // iterate through all grace chords
@@ -3589,7 +3594,7 @@ MuseScore {
         clog("hello n-edo");
 
         if (typeof curScore === 'undefined')
-              Qt.quit();
+              quit();
 
         var parms = {};
 
@@ -3619,6 +3624,6 @@ MuseScore {
         parms.currKeySig = parms.naturalKeySig
 
         applyToNotesInSelection(tuneNote, parms);
-        Qt.quit();
+        quit();
       }
 }

--- a/tune n-edo.qml
+++ b/tune n-edo.qml
@@ -4,9 +4,12 @@ import QtQuick.Controls.Styles 1.3
 import MuseScore 3.0
 
 MuseScore {
-      version: "2.3.3"
+      version: "2.4.0"
       description: "Retune selection to any EDO temperament, or whole score if nothing selected."
       menuPath: "Plugins.n-EDO.Tune"
+      title: "Tune"
+      categoryCode: "playback"
+      // thumbnailName: "something.png"
 
       // WARNING! This doesn't validate the accidental code!
       property variant customKeySigRegex: /\.(.*)\.(.*)\.(.*)\.(.*)\.(.*)\.(.*)\.(.*)/g
@@ -358,6 +361,7 @@ MuseScore {
       // or, if nothing is selected, in the entire score
 
       function applyToNotesInSelection(func, parms) {
+        curScore.startCmd();
         var cursor = curScore.newCursor();
         cursor.rewind(1);
         var startStaff;
@@ -576,7 +580,7 @@ MuseScore {
                 }
 
                 if (cursor.element) {
-                  if (cursor.element.type == Ms.CHORD) {
+                  if (cursor.element.type == Element.CHORD) {
                     var graceChords = cursor.element.graceNotes;
                     for (var i = 0; i < graceChords.length; i++) {
                       // iterate through all grace chords
@@ -596,6 +600,7 @@ MuseScore {
             }
           }
         }
+        curScore.endCmd();
       }
 
       // This will register an accidental's offset value and tick position.
@@ -937,7 +942,7 @@ MuseScore {
         console.log("hello n-edo");
 
         if (typeof curScore === 'undefined')
-              Qt.quit();
+              quit();
 
         var parms = {};
 
@@ -974,6 +979,6 @@ MuseScore {
         parms.accidentals = {};
 
         applyToNotesInSelection(tuneNote, parms);
-        Qt.quit();
+        quit();
       }
 }


### PR DESCRIPTION
Hopefully this is still compatible with Musescore 3.

One regression is that single notes don't have playbacks when pressing up/down anymore, this can be fixed by [manually playing back](https://musescore.org/en/node/327715). But I suspect if the `curScore.cmdStart/End()` are placed at the correct position there will be automatic playbacks.

- [ ] Test that this doesn't break Musescore 3.
- [ ] Test that this works in Musescore 4.
- [ ] See about the playback problem in Musescore 4.
- [ ] Wait for Musescore 4 API to stabilize? I think I'll be around these few weeks.
- [ ] Add some icons for the playback, like the official plugins in Musescore 4? I think I can do that if people want it.